### PR TITLE
event name typo fix. anync -> async.

### DIFF
--- a/index.es
+++ b/index.es
@@ -30,7 +30,8 @@ export default class PromisedReducer extends EventEmitter {
     this.emit(":update", this.state);
 
     if (inAsync) {
-      this.emit(":end-anync-updating");
+      this.emit(":end-anync-updating"); // for compatibility
+      this.emit(":end-async-updating");
     }
     return Promise.resolve();
   }


### PR DESCRIPTION
maybe, anync is typo.
